### PR TITLE
Fix duplicate URL issue not purging.

### DIFF
--- a/akamai.admin.inc
+++ b/akamai.admin.inc
@@ -331,7 +331,10 @@ function akamai_cache_control() {
  * Process the settings and submit to Akamai
  */
 function akamai_cache_control_submit($form, &$form_state) {
-  $paths = explode("\n", filter_xss($form_state['values']['paths']));
+  // filter_xss() does not need to be used here as it turns the & symbol into
+  // an HTML entity and v3 rejects it. We don't need HTML entites here as this
+  // data won't be used in actual HTML, just API requests.
+  $paths = explode("\n", $form_state['values']['paths']);
   $action = $form_state['values']['refresh'];
 
   $overrides = array(

--- a/akamai.module
+++ b/akamai.module
@@ -510,6 +510,8 @@ function akamai_clear_url($paths_in, $params = [], $node = NULL) {
     return FALSE;
   }
 
+  // This can cause the array to become non-associative and will cause
+  // json_encode() to use an object instead of an array when encoding.
   $paths = array_unique($paths);
 
   $default_params = array(

--- a/src/Ccu3Client.php
+++ b/src/Ccu3Client.php
@@ -44,7 +44,7 @@ class Ccu3Client extends BaseCcuClient implements CcuClientInterface {
       'hostname' => $hostname,
       'objects' => array_unique($paths),
     );
-    return json_encode($purge_body);
-  }
+    // Force a non-associative array for json_encode().
+    $purge_body['objects'] = array_values($purge_body['objects']);
 
 }

--- a/src/Ccu3Client.php
+++ b/src/Ccu3Client.php
@@ -47,4 +47,7 @@ class Ccu3Client extends BaseCcuClient implements CcuClientInterface {
     // Force a non-associative array for json_encode().
     $purge_body['objects'] = array_values($purge_body['objects']);
 
+    // Use JSON_UNESCAPED_SLASHES to reduce amount of data in request body.
+    return json_encode($purge_body, JSON_UNESCAPED_SLASHES);
+  }
 }


### PR DESCRIPTION
When submitting a list of URLs through the form and one is a duplicate it will fail with a poor error message referencing a partial error message and Guzzle.
